### PR TITLE
Remove locations query limit

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -130,7 +130,7 @@ export async function fetchNearbyProtests(position) {
     radius: 1000,
   });
 
-  const snapshot = await query.limit(35).get();
+  const snapshot = await query.limit(1000).get();
 
   const protests = snapshot.docs.map((doc) => {
     const { latitude, longitude } = doc.data().g.geopoint;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -130,7 +130,7 @@ export async function fetchNearbyProtests(position) {
     radius: 1000,
   });
 
-  const snapshot = await query.limit(1000).get();
+  const snapshot = await query.get();
 
   const protests = snapshot.docs.map((doc) => {
     const { latitude, longitude } = doc.data().g.geopoint;


### PR DESCRIPTION
currently locations query is limited to 35 locations, resulting in missing locations on the map.
i removed the limit.